### PR TITLE
Adds optional HTTP server for use when custom URI schemes are not available or disallowed

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -203,6 +203,17 @@ export default class AdvancedURI extends Plugin {
     }
 
     async requestListener(request: http.IncomingMessage, response: http.ServerResponse) {
+        if(request.method === 'GET') {
+            this.handleRequestMethodGet(request, response)
+        } else if(request.method === 'OPTIONS') {
+            this.handleRequestMethodOptions(request, response)
+        } else {
+            response.writeHead(405, "Method Not Allowed")
+            response.end()
+        }
+    }
+
+    async handleRequestMethodGet(request: http.IncomingMessage, response: http.ServerResponse) {
         try {
             const params: ObsidianProtocolData = {
                 action: 'advanced-uri'
@@ -215,12 +226,23 @@ export default class AdvancedURI extends Plugin {
 
             await this.handleUriAction(params)
 
-            response.writeHead(200, "OK")
+            response.writeHead(204, "OK", {
+                "Access-Control-Allow-Origin": "*"
+            })
             response.end()
         } catch(e) {
             response.writeHead(500, "Server Error")
             response.end()
         }
+    }
+
+    async handleRequestMethodOptions(request: http.IncomingMessage, response: http.ServerResponse) {
+        response.writeHead(204, "OK", {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, OPTIONS",
+            "Access-Control-Allow-Headers": "*",
+        })
+        response.end()
     }
 
     refreshServerState() {


### PR DESCRIPTION
Recently while poking around at the available tools for clipping content from browsers into Obsidian, I noticed that existing plugins have to use a hack for getting data into Obsidian due to browser security policies with regard to custom URI schemes (e.g. https://github.com/jplattel/obsidian-clipper#user-content-technical-explanation).

What this pull request adds is an optionally-enableable HTTP server that will allow users to dispatch requests directly to `obsidian-advanced-uri` by crafting a URL pointing at `http://localhost:27124` (by default) instead of `obsidian://advanced-uri` with the aim of allowing browser extensions to interact with Obsidian without requiring hacks like those described above.