### PR TITLE
Write to current file when file not specified

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -372,14 +372,14 @@ export default class AdvancedURI extends Plugin {
     }
 
     async handleWrite(parameters: Parameters, createdDailyNote: boolean = false) {
-        let file: TAbstractFile;
+        let file: TAbstractFile | null;
         if (parameters.filepath) {
             file = this.app.vault.getAbstractFileByPath(parameters.filepath);
         } else {
             file = this.app.workspace.getActiveFile();
         }
 
-        if (file) {
+        if (parameters.filepath || file) {
             let outFile: TFile;
             let path = parameters.filepath ?? file.path;
             if (parameters.mode === "overwrite") {


### PR DESCRIPTION
I enjoy using this plugin to quickly add entries to my daily note during the day. However, as a college student, sometimes my days go beyond midnight! Once into the next day, supplying `daily=true` to the file identification creates the next day's daily note, something that I don't want to happen until I sleep (past midnight) and wake up (the same day).

I noticed that the find and replace functionality didn't need a file identification, instead using the current open file if no identification is provided. Noticing this, we bring in the same logic into the `handleWrite()` function.

Tested appending on Windows and iOS.