### PR TITLE
Plugin Management: persistent and with notice

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -281,9 +281,13 @@ export default class AdvancedURI extends Plugin {
 
     handlePluginManagement(parameters: Parameters): void {
         if (parameters["enable-plugin"]) {
-            this.app.plugins.enablePlugin(parameters["enable-plugin"]);
+            const pluginId = parameters["enable-plugin"];
+            this.app.plugins.enablePluginAndSave(pluginId);
+            new Notice (`Enabled ${pluginId}`);
         } else if (parameters["disable-plugin"]) {
-            this.app.plugins.disablePlugin(parameters["disable-plugin"]);
+            const pluginId = parameters["disable-plugin"];
+            this.app.plugins.disablePluginAndSave(pluginId);
+            new Notice (`Disabled ${pluginId}`);
         }
     }
 


### PR DESCRIPTION
- added a notice, since plugin enabling/disabling is an action that not visible
- `[en|dis]ablePluginAndSave` is the better method, since it ensures that the enabling/disabling is persistent across app restart