### PR TITLE
add toggle to exclude vault param, and specify name vs. internal vault ID in copied URI

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,4 +9,6 @@ export const DEFAULT_SETTINGS: AdvancedURISettings = {
     useUID: false,
     addFilepathWhenUsingUID: false,
     allowEval: false,
+    includeVaultName: true,
+    vaultParam: "name",
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -69,6 +69,34 @@ export class SettingsTab extends PluginSettingTab {
                 })
             );
 
+        new Setting(containerEl)
+            .setName("Include vault name/ID parameter")
+            .addToggle((cb) =>
+                cb.setValue(this.plugin.settings.includeVaultName).onChange((value) => {
+                    this.plugin.settings.includeVaultName = value;
+                    this.plugin.saveSettings();
+                    this.display();
+                })
+            );
+
+        if (this.plugin.settings.includeVaultName) {
+            new Setting(containerEl)
+                .setName("Vault identifying parameter")
+                .setDesc(
+                    "Choose whether to use the vault Name or its internal ID as the identifying parameter."
+                )
+                .addDropdown((cb) =>
+                    cb
+                        .addOption('name', "Name")
+                        .addOption('id', "ID")
+                        .setValue(this.plugin.settings.vaultParam)
+                        .onChange((value) => {
+                            this.plugin.settings.vaultParam = value;
+                            this.plugin.saveSettings();
+                        })
+                );
+        }
+
         if (this.plugin.settings.useUID) {
             new Setting(containerEl)
                 .setName("Add filepath parameter")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,11 +72,13 @@ export class SettingsTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName("Include vault name/ID parameter")
             .addToggle((cb) =>
-                cb.setValue(this.plugin.settings.includeVaultName).onChange((value) => {
-                    this.plugin.settings.includeVaultName = value;
-                    this.plugin.saveSettings();
-                    this.display();
-                })
+                cb
+                    .setValue(this.plugin.settings.includeVaultName)
+                    .onChange((value) => {
+                        this.plugin.settings.includeVaultName = value;
+                        this.plugin.saveSettings();
+                        this.display();
+                    })
             );
 
         if (this.plugin.settings.includeVaultName) {
@@ -87,8 +89,8 @@ export class SettingsTab extends PluginSettingTab {
                 )
                 .addDropdown((cb) =>
                     cb
-                        .addOption('name', "Name")
-                        .addOption('id', "ID")
+                        .addOption("name", "Name")
+                        .addOption("id", "ID")
                         .setValue(this.plugin.settings.vaultParam)
                         .onChange((value) => {
                             this.plugin.settings.vaultParam = value;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -74,7 +74,7 @@ export default class Tools {
     }
 
     async generateURI(parameters: Parameters, doubleEncode: boolean) {
-        const prefix = 'obsidian://advanced-uri';
+        const prefix = "obsidian://advanced-uri";
         let suffix = "";
         const file = app.vault.getAbstractFileByPath(parameters.filepath);
         if (this.settings.includeVaultName) {
@@ -96,11 +96,10 @@ export default class Tools {
         }
         for (const parameter in parameters) {
             if ((parameters as any)[parameter] != undefined) {
-                suffix += suffix ? '&' : '?';
-                suffix +=
-                    `${parameter}=${encodeURIComponent(
-                        (parameters as any)[parameter]
-                    )}`;
+                suffix += suffix ? "&" : "?";
+                suffix += `${parameter}=${encodeURIComponent(
+                    (parameters as any)[parameter]
+                )}`;
             }
         }
         if (doubleEncode) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -82,7 +82,7 @@ export default class Tools {
             if (this.settings.vaultParam == "id" && app.appId) {
                 suffix += app.appId;
             } else {
-                suffix += await app.vault.getName();
+                suffix += app.vault.getName();
             }
         }
         if (

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -74,12 +74,17 @@ export default class Tools {
     }
 
     async generateURI(parameters: Parameters, doubleEncode: boolean) {
-        const prefix = `obsidian://advanced-uri?vault=${encodeURIComponent(
-            app.vault.getName()
-        )}`;
+        const prefix = 'obsidian://advanced-uri';
         let suffix = "";
         const file = app.vault.getAbstractFileByPath(parameters.filepath);
-
+        if (this.settings.includeVaultName) {
+            suffix += "?vault=";
+            if (this.settings.vaultParam == "id" && app.appId) {
+                suffix += app.appId;
+            } else {
+                suffix += await app.vault.getName();
+            }
+        }
         if (
             this.settings.useUID &&
             file instanceof TFile &&
@@ -91,9 +96,9 @@ export default class Tools {
         }
         for (const parameter in parameters) {
             if ((parameters as any)[parameter] != undefined) {
-                suffix =
-                    suffix +
-                    `&${parameter}=${encodeURIComponent(
+                suffix += suffix ? '&' : '?';
+                suffix +=
+                    `${parameter}=${encodeURIComponent(
                         (parameters as any)[parameter]
                     )}`;
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,8 @@ export interface AdvancedURISettings {
     useUID: boolean;
     addFilepathWhenUsingUID: boolean;
     allowEval: boolean;
+    includeVaultName: boolean;
+    vaultParam: 'id' | 'name';
 }
 
 export interface Parameters {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { PaneType, Plugin } from "obsidian";
+import { PaneType } from "obsidian";
 
 declare module "obsidian" {
     interface App {
@@ -18,6 +18,7 @@ declare module "obsidian" {
             activeTab: SettingTab;
             open(): void;
         };
+        appId: string;
         commands: {
             executeCommandById(id: string): void;
             commands: {
@@ -98,7 +99,7 @@ export interface AdvancedURISettings {
     addFilepathWhenUsingUID: boolean;
     allowEval: boolean;
     includeVaultName: boolean;
-    vaultParam: 'id' | 'name';
+    vaultParam: "id" | "name";
 }
 
 export interface Parameters {


### PR DESCRIPTION
Small FR that adds a toggle (`includeVaultName`) to allow the Vault Name parameter to be **excluded** from the copied URI.

Especially for users who use a single large "monovault", or who may have long vault names, this helps keep the URIs short and arguably more portable so they can survive vault renames etc.

The default for this setting is "ON" to align with the existing behavior and maintain compatibility.