### PR TITLE
add command for copy markdowned link

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -394,7 +394,7 @@ export default class Handlers {
         }
     }
 
-    handleCopyFileURI(withoutData: boolean, file?: TFile, asMarkdown: boolean = false) {
+    handleCopyFileURI(withoutData: boolean, asMarkdown: boolean = false, file?: TFile) {
         const view = app.workspace.getActiveViewOfType(FileView);
         if (!view && !file) return;
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -394,9 +394,21 @@ export default class Handlers {
         }
     }
 
-    handleCopyFileURI(withoutData: boolean, file?: TFile) {
+    handleCopyFileURI(withoutData: boolean, file?: TFile, asMarkdown: boolean = false) {
         const view = app.workspace.getActiveViewOfType(FileView);
         if (!view && !file) return;
+
+        // const copyFunc = asMarkdown ?
+        //     (parameters)=>this.tools.copyMarkdownLink(parameters) : (parameters) =>this.tools.copyURI(parameters);
+
+        let copyFunc =  (parameters: Parameters) => {
+            if (asMarkdown){
+                this.tools.copyMarkdownLink(parameters)
+            } else {
+                this.tools.copyURI(parameters)
+            }
+        }
+
         if (view instanceof MarkdownView) {
             const pos = view.editor.getCursor();
             const cache = app.metadataCache.getFileCache(view.file);
@@ -406,9 +418,10 @@ export default class Handlers {
                         heading.position.start.line <= pos.line &&
                         heading.position.end.line >= pos.line
                     ) {
-                        this.tools.copyURI({
+                        copyFunc({
                             filepath: view.file.path,
                             heading: heading.heading,
+                            markdownTitle: view.file.basename,
                         });
                         return;
                     }
@@ -421,9 +434,10 @@ export default class Handlers {
                         block.position.start.line <= pos.line &&
                         block.position.end.line >= pos.line
                     ) {
-                        this.tools.copyURI({
+                        copyFunc({
                             filepath: view.file.path,
                             block: blockID,
+                            markdownTitle: view.file.basename,
                         });
                         return;
                     }
@@ -437,8 +451,9 @@ export default class Handlers {
                 new Notice("No file opened");
                 return;
             }
-            this.tools.copyURI({
+            copyFunc({
                 filepath: file2.path,
+                markdownTitle: file2.basename,
             });
         } else {
             const fileModal = new FileModal(

--- a/src/main.ts
+++ b/src/main.ts
@@ -252,6 +252,14 @@ export default class AdvancedURI extends Plugin {
                             this.handlers.handleCopyFileURI(true, file)
                         );
                 });
+                menu.addItem((item)=>{
+                    item.setTitle("Copy Advanced URI (Markdown)")
+                        .setIcon("link")
+                        .setSection("info")
+                        .onClick((_)=>
+                            this.handlers.handleCopyFileURI(true, file, true)
+                        )
+                })
             })
         );
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,12 @@ export default class AdvancedURI extends Plugin {
         });
 
         this.addCommand({
+            id: "copy-uri-current-file-simple-markdown",
+            name: "copy URI for current file (Markdown)",
+            callback: () => this.handlers.handleCopyFileURI(true, true),
+        });
+
+        this.addCommand({
             id: "copy-uri-daily",
             name: "copy URI for daily note",
             callback: () => new EnterDataModal(this).open(),
@@ -105,20 +111,40 @@ export default class AdvancedURI extends Plugin {
             },
         });
 
-        this.addCommand({
-            id: "copy-uri-block",
-            name: "copy URI for current block",
-            checkCallback: (checking) => {
-                const view =
-                    this.app.workspace.getActiveViewOfType(MarkdownView);
-                if (checking) return view != undefined;
-                const id = BlockUtils.getBlockId();
-                if (id) {
+        let copyUriBlock = (checking: boolean, asMarkdown: boolean)=> {
+            const view =
+                this.app.workspace.getActiveViewOfType(MarkdownView);
+            if (checking) return view != undefined;
+            const id = BlockUtils.getBlockId();
+            if (id) {
+                if (asMarkdown) {
+                    this.tools.copyMarkdownLink({
+                        filepath: view.file.path,
+                        markdownTitle: view.file.basename,
+                        block: id,
+                    })
+                } else {
                     this.tools.copyURI({
                         filepath: view.file.path,
                         block: id,
                     });
                 }
+            }
+        };
+
+        this.addCommand({
+            id: "copy-uri-block",
+            name: "copy URI for current block",
+            checkCallback: (checking) => {
+                return copyUriBlock(checking, false)
+            },
+        });
+
+        this.addCommand({
+            id: "copy-uri-bm",
+            name: "copy URI for current block (Markdown)",
+            checkCallback: (checking) => {
+                return copyUriBlock(checking, true)
             },
         });
 
@@ -249,7 +275,7 @@ export default class AdvancedURI extends Plugin {
                         .setIcon("link")
                         .setSection("info")
                         .onClick((_) =>
-                            this.handlers.handleCopyFileURI(true, file)
+                            this.handlers.handleCopyFileURI(true, false, file)
                         );
                 });
                 menu.addItem((item)=>{
@@ -257,7 +283,7 @@ export default class AdvancedURI extends Plugin {
                         .setIcon("link")
                         .setSection("info")
                         .onClick((_)=>
-                            this.handlers.handleCopyFileURI(true, file, true)
+                            this.handlers.handleCopyFileURI(true, true, file)
                         )
                 })
             })

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -77,6 +77,7 @@ export default class Tools {
         const prefix = "obsidian://advanced-uri";
         let suffix = "";
         const file = app.vault.getAbstractFileByPath(parameters.filepath);
+        parameters.markdownTitle = undefined; // no need copy title
         if (this.settings.includeVaultName) {
             suffix += "?vault=";
             if (this.settings.vaultParam == "id" && app.appId) {
@@ -114,6 +115,16 @@ export default class Tools {
         await copyText(uri);
 
         new Notice("Advanced URI copied to your clipboard");
+    }
+
+    async copyMarkdownLink(parameters: Parameters) {
+        const markdownTitle = parameters.markdownTitle ? parameters.markdownTitle : "";
+        const uri = await this.generateURI(parameters, true);
+        const markdownLink = "[" + markdownTitle + "](" + uri + ")";
+
+        new Notice("Advanced URI copied to your clipboard (Markdown)");
+
+        await copyText(markdownLink);
     }
 
     getFileFromUID(uid: string): TFile | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,8 @@ export interface Parameters {
     saveworkspace?: "true";
     updateplugins?: "true";
     line?: number;
+    markdownTitle?: string;
+
     /**
      * @deprecated Use "openMode" instead
      */


### PR DESCRIPTION
Let's add copy link to a note as markdown, with filename as title.