### PR TITLE
feat: allow appending / prepending at line

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -359,11 +359,8 @@ export default class AdvancedURI extends Plugin {
                 path = file.path;
                 const fileData = await this.app.vault.read(file);
                 if (parameters.line) {
-                    let line = Math.max(Number(parameters.line) - 1, 0);
+                    let line = Math.max(Number(parameters.line), 0);
                     const lines = fileData.split("\n");
-                    if (lines[line]?.trim() !== "") {
-                        line += 1;
-                    }
                     lines.splice(line, 0, parameters.data);
                     dataToWrite = lines.join("\n");
                 } else {
@@ -405,10 +402,10 @@ export default class AdvancedURI extends Plugin {
                 const fileData = await this.app.vault.read(file);
                 const cache = this.app.metadataCache.getFileCache(file);
                 let line = 0;
-                if (cache.frontmatterPosition) {
-                    line += cache.frontmatterPosition.end.line + 1;
-                } else if (parameters.line) {
+                if (parameters.line) {
                     line += Math.max(Number(parameters.line) - 1, 0);
+                } else if (cache.frontmatterPosition) {
+                    line += cache.frontmatterPosition.end.line + 1;
                 }
                 const lines = fileData.split("\n");
                 lines.splice(line, 0, parameters.data);

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,7 @@ export interface Parameters {
     "x-error"?: string;
     saveworkspace?: "true";
     updateplugins?: "true";
-    line?: number;
+    line?: string;
     /**
      * @deprecated Use "openMode" instead
      */


### PR DESCRIPTION
This PR makes it possible to combine `mode=append` / `prepend` with the `line` parameter. 

To illustrate the difference in behavior between the two cases, this is what happens when we **append** three times in a row at line 2:

```
1
2 first
3
```

```
1
2 first
3 second
4
```

```
1
2 first
3 third
4 second
5
```

And when we **prepend**:

```
1
2 first
3
```

```
1
2 second
3 first
4
```

```
1
2 third
3 second
4 first
5
```

I played around with a couple of other alternatives:

1. Appending at the first non-empty line (so the example above would show `first, second, third`)
2. Just making the two operations work the same way, to always insert at the specified line

The behavior in this PR made the most intuitive sense, since we're appending immediately _after_ whatever is on the line and prepending immediately _before_, but let me know if you disagree.

---

I tested the following cases manually:

1. Appending / prepending at line
2. Appending / prepending into an empty file (works as before)
5. Prepending into a file that contains frontmatter (works as before)

I also changed the type of `parameters.number`, since `decodeURIComponent` always returns strings.

I wasn't able to find anything in the documentation about this behavior, but let me know if you'd like me to add a mention there, to.