### PR TITLE
docs: add community plugin settings example

### DIFF
--- a/docs/docs/actions/settings_navigation.md
+++ b/docs/docs/actions/settings_navigation.md
@@ -47,12 +47,17 @@ The settings tab of every community plugin can be opened by the plugin's id. The
 In addition to navigating to a specific setting, you can also navigate to a specific section of a setting. This is useful if you want to open a specific setting and have it scrolled into view. Use the additional `settingsection` parameter for this purpose. The parameter's value is the exact case-sensitive section name.
 
 
-:::note Example
+:::note Example for Obsidian Settings
 ```uri
 obsidian://advanced-uri?vault=<your-vault>&settingid=editor
 ```
 ```uri
 obsidian://advanced-uri?vault=<your-vault>&settingid=editor&settingsection=Behavior
+```
+
+:::note Example for Community Plugins Options Page
+```uri
+obsidian://advanced-uri?vault=Manifold-Grace&settingid=<community plugin id>
 ```
 :::
 


### PR DESCRIPTION
While setting up my PKM where I document several plugins, it came to me that advanced URI could open the options page for any community plugin. It took a while to figure it out. The reason of my edit is to add a clearer example that would help the community to form the plugin URI.