### PR TITLE
fix: detect sections correctly

### DIFF
--- a/src/block_utils.ts
+++ b/src/block_utils.ts
@@ -15,23 +15,18 @@ export abstract class BlockUtils {
     ): (SectionCache | ListItemCache) | undefined {
         const cursor = editor.getCursor("to");
         const fileCache = app.metadataCache.getFileCache(file);
-
-        let currentBlock: SectionCache | ListItemCache =
-            fileCache?.sections?.find(
-                (section) =>
-                    section.position.start.line <= cursor.line &&
-                    section.position.end.line >= cursor.line
-            );
-
-        if (currentBlock.type == "list") {
-            currentBlock = fileCache.listItems?.find((list) => {
-                if (
-                    list.position.start.line <= cursor.line &&
-                    list.position.end.line >= cursor.line
-                ) {
-                    return list;
-                }
-            });
+        const sections = fileCache?.sections;
+        if (!sections || sections.length === 0) {
+            console.log('error reading FileCache (empty file?)');
+            return;
+        }
+        const foundSectionIndex = sections.findIndex(section => section.position.start.line > cursor.line);
+        let currentBlock: SectionCache | ListItemCache = foundSectionIndex > 0 ? sections[foundSectionIndex - 1] : sections[sections.length - 1];
+        if (currentBlock?.type == "list") {
+            currentBlock = fileCache.listItems?.find(section =>
+                section.position.start.line <= cursor.line &&
+                section.position.end.line >= cursor.line
+            ) ?? currentBlock;
         }
         return currentBlock;
     }


### PR DESCRIPTION
## Abstract

I noticed today that I was getting JS errors in the console when trying to use the **Copy URI for current block** command under certain conditions:

### A section with no text in it e.g.

```
# Section I haven't written yet

{cursor here} <==

# Another section
...
```
![image](https://github.com/Vinzent03/obsidian-advanced-uri/assets/1992842/3ed5ef5f-6c07-4dda-96f1-90ce962554a5)

### Cursor at very end of file

![image](https://github.com/Vinzent03/obsidian-advanced-uri/assets/1992842/429f176c-0fdc-49f5-836b-337b7c5b2401)

### File empty / contains no sections

![image](https://github.com/Vinzent03/obsidian-advanced-uri/assets/1992842/0d962cd1-9e51-4d4d-a46f-3e83005eeb60)

Here's a PR I came up with that resolves these cases. I did some testing and seems fine, but please comment with any more changes needed.

## Screenshots from this fork

empty section
![](https://github.com/Vinzent03/obsidian-advanced-uri/assets/1992842/0ffc1239-e15a-448a-93dc-9cf8ee0433bd)

end of file
![](https://github.com/Vinzent03/obsidian-advanced-uri/assets/1992842/51e9b5ff-5142-4b60-8658-4a7b162f7ad7)

empty file
![](https://github.com/Vinzent03/obsidian-advanced-uri/assets/1992842/339cdf39-ed5d-42f2-b79f-e97d2bebc945)
