### PR TITLE
Allow user to customize separator when using prepend/append

### DIFF
--- a/docs/Actions/Writing.md
+++ b/docs/Actions/Writing.md
@@ -36,4 +36,20 @@
 > ```
 
 > [!note]
+> When using `prepend` / `append` mode, the default separator is `\n`. The `separator` parameter 
+> could be used to customize the separator.
+> 
+> For example:
+> 
+> ```
+> obsidian://adv-uri?vault=<your-vault>&filepath=my-file&data=new_data&mode=append&separator=,
+> ```
+> 
+> This will result in the original data and the new data being separated by a comma `,`
+> 
+> ```
+> original_data,new_data
+> ```
+
+> [!note]
 You may use the `heading` or `line` parameter to append and prepend data to a heading or line. More information in [Navigation](Actions/Navigation)

--- a/src/main.ts
+++ b/src/main.ts
@@ -385,9 +385,7 @@ export default class AdvancedURI extends Plugin {
 
         const options = {
             title: stripMD(file.name),
-            advanceduri: await this.tools.generateURI(
-                { filepath: file.path }
-            ),
+            advanceduri: await this.tools.generateURI({ filepath: file.path }),
             urlkey: "advanceduri",
             fileuri: getFileUri(this.app, file),
         };
@@ -417,39 +415,35 @@ export default class AdvancedURI extends Plugin {
     async append(file: TFile | string, parameters: Parameters): Promise<TFile> {
         let path: string;
         let dataToWrite: string;
-        if (parameters.heading) {
-            if (file instanceof TFile) {
-                path = file.path;
-                const line = getEndAndBeginningOfHeading(
+
+        if (file instanceof TFile) {
+            path = file.path;
+            const data = await this.app.vault.read(file);
+            const lines = data.split("\n");
+
+            // determine which line to perform append operation
+            let line: number = undefined; // 1-indexed
+            if (parameters.heading) {
+                line = getEndAndBeginningOfHeading(
                     this.app,
                     file,
                     parameters.heading
                 )?.lastLine;
                 if (line === undefined) return;
-
-                const data = await this.app.vault.read(file);
-                const lines = data.split("\n");
-
-                lines.splice(line, 0, ...parameters.data.split("\n"));
-                dataToWrite = lines.join("\n");
-            }
-        } else {
-            if (file instanceof TFile) {
-                path = file.path;
-                const fileData = await this.app.vault.read(file);
-                if (parameters.line) {
-                    let line = Math.max(Number(parameters.line), 0);
-                    const lines = fileData.split("\n");
-                    lines.splice(line, 0, parameters.data);
-                    dataToWrite = lines.join("\n");
-                } else {
-                    dataToWrite = fileData + "\n" + parameters.data;
-                }
+            } else if (parameters.line) {
+                line = Number(parameters.line);
             } else {
-                path = file;
-                dataToWrite = parameters.data;
+                line = lines.length;
             }
+
+            line = Math.max(1, line);
+            lines[line - 1] += (parameters.separator ?? "\n") + parameters.data;
+            dataToWrite = lines.join("\n");
+        } else {
+            path = file;
+            dataToWrite = parameters.data;
         }
+
         return this.writeAndOpenFile(path, dataToWrite, parameters);
     }
 
@@ -459,40 +453,46 @@ export default class AdvancedURI extends Plugin {
     ): Promise<TFile> {
         let path: string;
         let dataToWrite: string;
-        if (parameters.heading) {
-            if (file instanceof TFile) {
-                path = file.path;
-                const line = getEndAndBeginningOfHeading(
+
+        if (file instanceof TFile) {
+            path = file.path;
+            const data = await this.app.vault.read(file);
+            const cache = this.app.metadataCache.getFileCache(file);
+
+            const lines = data.split("\n");
+
+            // determine which line to perform prepend operation
+            let line = undefined; // 1-indexed
+            if (parameters.heading) {
+                line = getEndAndBeginningOfHeading(
                     this.app,
                     file,
                     parameters.heading
                 )?.firstLine;
-                if (line === undefined) return;
-
-                const data = await this.app.vault.read(file);
-                const lines = data.split("\n");
-
-                lines.splice(line, 0, ...parameters.data.split("\n"));
-                dataToWrite = lines.join("\n");
-            }
-        } else {
-            if (file instanceof TFile) {
-                path = file.path;
-                const fileData = await this.app.vault.read(file);
-                const cache = this.app.metadataCache.getFileCache(file);
-                let line = 0;
-                if (parameters.line) {
-                    line += Math.max(Number(parameters.line) - 1, 0);
-                } else if (cache.frontmatterPosition) {
-                    line += cache.frontmatterPosition.end.line + 1;
+                if (line === undefined) {
+                    return;
+                } else {
+                    line += 1;
                 }
-                const lines = fileData.split("\n");
-                lines.splice(line, 0, parameters.data);
-                dataToWrite = lines.join("\n");
+            } else if (parameters.line) {
+                line = Number(parameters.line);
+            } else if (cache.frontmatterPosition) {
+                // +1 to convert 0-indexed to 1-indexed
+                // another +1 to ensure prepend operation performed
+                // at the next line of the end of frontmatter
+                line = cache.frontmatterPosition.end.line + 2;
             } else {
-                path = file;
-                dataToWrite = parameters.data;
+                line = 1;
             }
+
+            line = Math.max(1, line);
+            lines[line - 1] = `${parameters.data}${
+                parameters.separator ?? "\n"
+            }${lines[line - 1]}`;
+            dataToWrite = lines.join("\n");
+        } else {
+            path = file;
+            dataToWrite = parameters.data;
         }
 
         return this.writeAndOpenFile(path, dataToWrite, parameters);

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,6 +122,7 @@ export interface Parameters {
     filepath?: string;
     daily?: "true";
     data?: string;
+    separator?: string;
     mode?: "overwrite" | "append" | "prepend" | "new";
     heading?: string;
     block?: string;


### PR DESCRIPTION
Add a new parameter `separator` that allows user to specify the separator for prepend/append operation instead of the default `\n`. (Resolved #194 )

Also did some refactor to `prepend` and `append` code to make it clearer.