### PR TITLE
feat: new 'await-sync' parameter

### DIFF
--- a/docs/Actions/Writing.md
+++ b/docs/Actions/Writing.md
@@ -57,3 +57,6 @@
 
 > [!note]
 You may use the `heading` or `line` parameter to append and prepend data to a heading or line. More information in [Navigation](Actions/Navigation)
+
+> [!note]
+When using Obsidian Sync, you can add the parameter `await-sync=true` to wait until the sync is complete before proceeding with the write operation. This ensures that any changes are synchronized across your devices before the write action is executed.

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import {
     appHasDailyNotesPluginLoaded,
     getDailyNotePath,
 } from "./daily_note_utils";
+import { awaitSyncCompletion } from "./sync_utils";
 import Handlers from "./handlers";
 import { CommandModal } from "./modals/command_modal";
 import { EnterDataModal } from "./modals/enter_data_modal";
@@ -384,6 +385,10 @@ export default class AdvancedURI extends Plugin {
     }
 
     async chooseHandler(parameters: Parameters, createdDailyNote: boolean) {
+        if (parameters["await-sync"] === "true") {
+            await awaitSyncCompletion(this.app);
+        }
+
         if (parameters["enable-plugin"] || parameters["disable-plugin"]) {
             this.handlers.handlePluginManagement(parameters);
         } else if (parameters.workspace || parameters.saveworkspace == "true") {

--- a/src/sync_utils.ts
+++ b/src/sync_utils.ts
@@ -1,4 +1,4 @@
-import { App } from "obsidian";
+import { App, Notice } from "obsidian";
 
 type SyncInstance = {
     syncing: boolean;
@@ -38,11 +38,19 @@ export const awaitSyncCompletion = async (app: App): Promise<void> => {
         await new Promise((resolve) => setTimeout(resolve, 1000));
     }
 
-    while (sync.syncing === true) {
+    let notice;
+    while (sync.syncing === true && sync.syncStatus !== 'Indexing...') {
         console.log(
             "waiting for sync to complete, current status:",
             sync.syncStatus
         );
+        if (!notice) {
+            notice = new Notice("Waiting for sync to complete...");
+        }
         await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    if (notice) {
+        notice.hide();
     }
 };

--- a/src/sync_utils.ts
+++ b/src/sync_utils.ts
@@ -4,6 +4,7 @@ type SyncInstance = {
     syncing: boolean;
     ready: boolean;
     syncStatus: string;
+    plugin: { enabled: boolean };
 };
 
 const getSyncInstance = (app: App): SyncInstance => {
@@ -14,6 +15,11 @@ export const awaitSyncCompletion = async (app: App): Promise<void> => {
     let sync = getSyncInstance(app);
     if (!sync) {
         console.log("sync instance not found, not waiting");
+        return;
+    }
+
+    if (sync?.plugin?.enabled !== true) {
+        console.log("sync plugin is disabled, not waiting");
         return;
     }
 

--- a/src/sync_utils.ts
+++ b/src/sync_utils.ts
@@ -1,0 +1,42 @@
+import { App } from "obsidian";
+
+type SyncInstance = {
+    syncing: boolean;
+    ready: boolean;
+    syncStatus: string;
+};
+
+const getSyncInstance = (app: App): SyncInstance => {
+    return (app.internalPlugins?.plugins?.sync as any)?.instance;
+};
+
+export const awaitSyncCompletion = async (app: App): Promise<void> => {
+    let sync = getSyncInstance(app);
+    if (!sync) {
+        console.log("sync instance not found, not waiting");
+        return;
+    }
+
+    if (!("syncing" in sync) || !("ready" in sync)) {
+        console.log(
+            "sync instance does not have expected properties, not waiting"
+        );
+        return;
+    }
+
+    while (sync.ready === false) {
+        console.log(
+            "waiting for sync to be ready, current status:",
+            sync.syncStatus
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    while (sync.syncing === true) {
+        console.log(
+            "waiting for sync to complete, current status:",
+            sync.syncStatus
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+};

--- a/src/sync_utils.ts
+++ b/src/sync_utils.ts
@@ -30,27 +30,41 @@ export const awaitSyncCompletion = async (app: App): Promise<void> => {
         return;
     }
 
+    let notice: Notice | null = null;
+    let tryCount = 0;
     while (sync.ready === false) {
-        console.log(
-            "waiting for sync to be ready, current status:",
-            sync.syncStatus
-        );
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-
-    let notice;
-    while (sync.syncing === true && sync.syncStatus !== 'Indexing...') {
-        console.log(
-            "waiting for sync to complete, current status:",
-            sync.syncStatus
-        );
-        if (!notice) {
-            notice = new Notice("Waiting for sync to complete...");
+        tryCount++;
+        // Wait for up to 10 seconds for sync to be ready
+        if (tryCount > 40) {
+            console.log(
+                "sync instance not ready after 10 seconds, not waiting"
+            );
+            notice?.hide();
+            return;
         }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        if (tryCount > 6 && !notice) {
+            notice = new Notice("Adv. URI: Waiting for sync to complete...", 0);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250));
     }
 
-    if (notice) {
-        notice.hide();
+    while (sync.syncing === true && sync.syncStatus !== "Indexing...") {
+        tryCount++;
+        // Wait for up to 60 seconds for syncing to complete
+        if (tryCount > 240) {
+            console.log(
+                "sync instance still syncing after 60 seconds, not waiting"
+            );
+
+            notice?.hide();
+            return;
+        }
+        if (tryCount > 6 && !notice) {
+            notice = new Notice("Adv. URI: Waiting for sync to complete...", 0);
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 250));
     }
+
+    notice?.hide();
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,7 @@ export interface Parameters {
     canvasviewport?: string;
     confirm?: string;
     offset?: string;
+    ['await-sync']?: "true" | "false";
 }
 
 export type OpenMode = "silent" | "popover" | PaneType | "true" | "false";

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,7 +188,7 @@ export interface Parameters {
     canvasviewport?: string;
     confirm?: string;
     offset?: string;
-    ['await-sync']?: "true" | "false";
+    "await-sync"?: "true" | "false";
 }
 
 export type OpenMode = "silent" | "popover" | PaneType | "true" | "false";


### PR DESCRIPTION
This implements a new `await-sync=true` parameter that can be used to wait for Obsidian Sync to complete.

Since this relies on internal APIs, I've tried to make it as defensive as possible, so that it won't break on changes in the Obsidian Sync plugin.

@Vinzent03 not sure if you actually want to merge this, but wanted to give it a try myself once I saw your comment on the issue, seems like it was easier than I expected. Let me know if you'd like me to make changes, or if you'd rather not include this, and I'll close this PR.

Tested with this URL:

```
obsidian://adv-uri?vault=notes&daily=true&data=Hello%20World&mode=append&await-sync=true
```

---

Fixes #218